### PR TITLE
fix: Google maps authorization issue in Feed

### DIFF
--- a/features/feed/src/main/AndroidManifest.xml
+++ b/features/feed/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <application>
         <meta-data
-            android:name="com.google.android.geo.API_KEY"
+            android:name="com.google.android.maps.v2.API_KEY"
             android:value="${MAPS_API_KEY}" />
     </application>
 


### PR DESCRIPTION
When opening the Feed details for a trip, currently we get the following error 
```
E/Google Maps Android API: Authorization failure.  Please see https://developers.google.com/maps/documentation/android-api/start for how to correctly set up the map.
E/Google Maps Android API: In the Google Developer Console (https://console.developers.google.com)
    Ensure that the "Google Maps Android API v2" is enabled.
    Ensure that the following Android Key exists:
    	API Key: "<GOOGLE_MAPS_API_KEY>"
    	Android Application (<cert_fingerprint>;<package_name>): <APPLICATION_SHA>;<APPLICATION_ID>
```
This is fixed when we change the value of `android:name` property in the feed module's manifest file.